### PR TITLE
Move tutorial content to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
 This directory contains utilities that facilitate running WDLs through the Broad's Cromwell execution engine on the Google Cloud Platform. 
+# WDL Runner
 
-#### wdl_runner
+Welcome to the WDL Runner repository.
 
-The `wdl_runner` is a wrapper package that handles spinning up a Cromwell server on a GCP VM and launching a WDL workflow by submitting it to the newly created Cromwell server. See the `wdl_runner` [README](wdl_runner/README.md) for a detailed tutorial that explains how to use it in practice.
+If you are a user and would like some more user-facing documentation, see [readthedocs](https://wdl-runner.readthedocs.io/en/latest/).
 
-#### monitoring_tools
+## Repository Contents
 
-These are scripts that facilitate monitoring the status of WDL workflows run on GCP. The main monitoring script is `monitor_wdl_pipeline.sh`. It accepts an operation ID for a pipeline, extracts the LOGGING, WORKSPACE, and OUTPUT directories from the operation and then examines these directories to glean some insights into the status of the operation.
+The repo has directories containing the following contents.
+
+## Docs
+
+These are the source pages which feed our [readthedocs](https://wdl-runner.readthedocs.io/en/latest/) pages.
+
+## The wdl_runner tool
+
+Source code for the `wdl_runner` tool. This is a convenient tool which handles:
+ 
+ * Spinning up a Cromwell server on a GCP VM 
+ * Launching a WDL workflow by submitting it to the newly created Cromwell server. 
+
+## Additional Monitoring Tools
+
+Additional monitoring tools are stored in the '[monitoring_tools](https://github.com/broadinstitute/wdl-runner/tree/master/monitoring_tools)' directory of the
+`wdl-runner` repository.
+
+These are scripts that facilitate monitoring the status of WDL workflows run on GCP. 
+The main monitoring script is `monitor_wdl_pipeline.sh`. 
+It accepts an operation ID for a pipeline, extracts the LOGGING, WORKSPACE, and OUTPUT directories from the operation 
+and then examines these directories to glean some insights into the status of the operation.
 
 Note that if the WORKSPACE and/or OUTPUT directories for the specified operation are already populated (for example by another operation), this script will emit incorrect output.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-This directory contains utilities that facilitate running WDLs through the Broad's Cromwell execution engine on the Google Cloud Platform. 
 # WDL Runner
 
 Welcome to the WDL Runner repository.
+
+This repo contains utilities that facilitate running WDL workflows through the Broad's Cromwell execution engine on the Google Cloud Platform (GCP).
 
 If you are a user and would like some more user-facing documentation, see [readthedocs](https://wdl-runner.readthedocs.io/en/latest/).
 

--- a/docs/GettingStarted/QuickStart.md
+++ b/docs/GettingStarted/QuickStart.md
@@ -2,23 +2,25 @@
 
 This page is intended to be our first-stop tutorial for those new to using wdl_runner.
 
-## In case there are errors...
+## Note: just in case there are errors...
 
 We want this page to be as useful to completely new users as possible. If you find *anything* on this page which is:
 
+* Not correct
 * Not obvious to you
-* Making undeclared assumptions about:
-  * What you know
-  * What you have installed
-  * What your local machine setup looks like
-  * What you have already done to begin setting up
+* Making undeclared assumptions
 * Worded obtusely
   
 Then:
  
-* Please (please!) raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
-* If you can use github, and you are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
+* Please (please!) let us know!
+    * You can raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
+    * If you use github and are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
 
+
+# Tutorial
+
+With that said, let's get started!
 
 ## Overview
 
@@ -50,9 +52,13 @@ Execution of a running Pipeline proceeds as:
     c. Poll for completion as Cromwell executes:
 
         1) Call pipelines.run() to execute call 1
+        
         2) Poll for completion of call 1
+        
         3) Call pipelines.run() to execute call 2
+        
         4) Poll for completion of call 2
+        
         <etc. until all WDL "calls" complete>
 
     d. Copy workflow metadata to output path

--- a/docs/GettingStarted/QuickStart.md
+++ b/docs/GettingStarted/QuickStart.md
@@ -1,0 +1,259 @@
+# Quick Start
+
+This page is intended to be our first-stop tutorial for those new to using wdl_runner.
+
+## In case there are errors...
+
+We want this page to be as useful to completely new users as possible. If you find *anything* on this page which is:
+
+* Not obvious to you
+* Making undeclared assumptions about:
+  * What you know
+  * What you have installed
+  * What your local machine setup looks like
+  * What you have already done to begin setting up
+* Worded obtusely
+  
+Then:
+ 
+* Please (please!) raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
+* If you can use github, and you are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
+
+
+## Overview
+
+This example demonstrates running a multi-stage workflow on
+Google Cloud Platform.
+
+* The workflow is launched with the Google Genomics [Pipelines API](https://cloud.google.com/genomics/docs/quickstart).
+* The workflow is defined using the OpenWDL organization's
+[Workflow Definition Language](https://github.com/openwdl/wdl) (WDL).
+* The workflow stages are orchestrated by the Broad Institute's
+[Cromwell](https://github.com/broadinstitute/cromwell).
+
+When submitted using the Pipelines API, the workflow runs
+on multiple [Google Compute Engine](https://cloud.google.com/compute/)
+virtual machines.
+First a master node is created for Cromwell, and then Cromwell submits
+each stage of the workflow as one or more separate pipelines.
+
+Execution of a running Pipeline proceeds as:
+
+1. Create Compute Engine virtual machine
+
+2. On the VM, in a Docker container, execute wdl_runner.py
+
+    a. Run Cromwell (server)
+
+    b. Submit workflow, inputs, and options to Cromwell server
+
+    c. Poll for completion as Cromwell executes:
+
+        1) Call pipelines.run() to execute call 1
+        2) Poll for completion of call 1
+        3) Call pipelines.run() to execute call 2
+        4) Poll for completion of call 2
+        <etc. until all WDL "calls" complete>
+
+    d. Copy workflow metadata to output path
+
+    e. Copy workflow outputs to output path
+
+3. Destroy Compute Engine Virtual machine
+
+## Setup Overview
+
+Code packaging for the Pipelines API is done through
+[Docker](https://www.docker.com/) images.  The instructions provided
+here explain how to create your own Docker image, although a copy
+of this Docker image has already been built and made available by
+the Broad Institute.
+
+### Code summary
+
+The code in the wdl_runner Docker image includes:
+
+* [OpenJDK 8](http://openjdk.java.net/projects/jdk8/) runtime engine (JRE)
+* [Python 2.7](https://www.python.org/download/releases/2.7/) interpreter
+* [Cromwell release 36](https://github.com/broadinstitute/cromwell/releases/tag/36)
+* [Python and shell scripts from this repository](.)
+
+Take a look at the [Dockerfile](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/Dockerfile) for full details.
+
+## (0) Prerequisites
+
+1. Clone or fork this repository.
+
+2. Enable the Genomics, Cloud Storage, and Compute Engine APIs on a new
+   or existing Google Cloud Project using the [Cloud Console](https://console.cloud.google.com/flows/enableapi?apiid=genomics,storage_component,compute_component&redirect=https://console.cloud.google.com)
+
+3. Follow the Google Genomics [getting started instructions](https://cloud.google.com/genomics/docs/quickstart) to install and authorize the Google Cloud SDK.
+
+4. Follow the Cloud Storage instructions for [Creating Storage Buckets](https://cloud.google.com/storage/docs/creating-buckets) to create a bucket for workflow output and logging 
+
+5. If you plan to create your own Docker images, then
+[install docker](https://docs.docker.com/engine/installation/#installation)
+
+## (1) Create and stage the wdl_runner Docker image
+
+*If you are going to use the published version of the docker image,
+then skip this step.*
+
+Every Google Cloud project provides a private repository for saving and
+serving Docker images called the [Google Container Registry](https://cloud.google.com/container-registry/docs/).
+
+The following instructions allow you to stage a Docker image in your project's
+Container Registry with all necessary code for orchestrating your workflow.
+
+### (1a) Create the Docker image.
+
+```
+git clone https://github.com/broadinstitute/wdl.git
+cd runners/cromwell_on_google/wdl_runner/
+docker build -t ${USER}/wdl_runner .
+```
+
+### (1b) Push the Docker image to a repository.
+
+In this example, we push the container to
+[Google Container Registry](https://cloud.google.com/container-registry/)
+via the following commands:
+
+```
+docker tag ${USER}/wdl_runner gcr.io/YOUR-PROJECT-ID/wdl_runner
+gcloud docker -- push gcr.io/YOUR-PROJECT-ID/wdl_runner
+```
+
+* Replace `YOUR-PROJECT-ID` with your project ID.
+
+## (2) Run a test workflow in the cloud
+
+The file [wdl_pipeline.yaml](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/wdl_pipeline.yaml)
+defines a pipeline for running WDL workflows. By default, it uses the
+docker image built by the Broad Institute from this repository:
+
+```
+docker:
+  imageName: gcr.io/broad-dsde-outreach/wdl_runner:<datestamp>
+```
+
+If you have built your own Docker image, then change the imageName:
+
+```
+docker:
+  imageName: gcr.io/YOUR-PROJECT-ID/wdl_runner
+```
+
+* Replace `YOUR-PROJECT-ID` with your project ID.
+
+#### Run the following command:
+
+* Replace `YOUR-BUCKET` with a bucket in your project.
+
+```
+gcloud \
+  alpha genomics pipelines run \
+  --pipeline-file wdl_pipeline.yaml \
+  --regions us-central1 \
+  --inputs-from-file WDL=test-wdl/ga4ghMd5.wdl,\
+WORKFLOW_INPUTS=test-wdl/ga4ghMd5.inputs.json,\
+WORKFLOW_OPTIONS=test-wdl/basic.papi.us.options.json \
+  --env-vars WORKSPACE=gs://YOUR-BUCKET/wdl_runner/work,\
+OUTPUTS=gs://YOUR-BUCKET/wdl_runner/output \
+  --logging gs://YOUR-BUCKET/wdl_runner/logging
+```
+
+The output will be an operation ID for the Pipeline.
+
+## (3) Monitor the pipeline operation
+
+This github repo includes a shell script,
+[monitoring_tools/monitor_wdl_pipeline.sh](https://github.com/broadinstitute/wdl-runner/blob/master/monitoring_tools/monitor_wdl_pipeline.sh),
+for monitoring the status of a pipeline launched using ``wdl_pipeline.yaml``.
+
+```
+$ ./monitoring_tools/monitor_wdl_pipeline.sh YOUR-NEW-OPERATION-ID
+Logging: gs://YOUR-BUCKET/wdl_runner/logging
+Workspace: gs://YOUR-BUCKET/wdl_runner/work
+Outputs: gs://YOUR-BUCKET/wdl_runner/output
+
+2017-10-04 00:18:45: operation not complete
+No operations logs found.
+There are 0 output files
+Sleeping 60 seconds
+
+2017-10-04 00:19:50: operation not complete
+Sleeping 60 seconds
+
+2017-10-04 00:20:54: operation not complete
+Calls started but not complete:
+  ga4ghMd5/CALL_HASH/call-md5
+Total Preemptions: 0
+Sleeping 60 seconds
+
+2017-10-04 00:21:59: operation not complete
+Calls (including shards) completed:  1
+Calls started but not complete:
+  ga4ghMd5/CALL_HASH/call-md5
+Sleeping 60 seconds
+
+2017-10-04 00:23:04: operation complete
+Completed operation status information
+  done: true
+  metadata:
+    events:
+    - description: start
+      startTime: '2017-10-04T04:18:59.394089075Z'
+    - description: pulling-image
+      startTime: '2017-10-04T04:18:59.394719563Z'
+    - description: localizing-files
+      startTime: '2017-10-04T04:19:38.809811533Z'
+    - description: running-docker
+      startTime: '2017-10-04T04:19:38.809854495Z'
+    - description: delocalizing-files
+      startTime: '2017-10-04T04:22:22.720332568Z'
+    - description: ok
+      startTime: '2017-10-04T04:22:24.464250806Z'
+  name: operations/YOUR-NEW-OPERATION-ID
+Operation output
+  gs://YOUR-BUCKET/wdl_runner/output/md5sum.txt
+  gs://YOUR-BUCKET/wdl_runner/output/wdl_run_metadata.json
+
+Preemption retries:
+  None
+```
+
+## (4) Check the results
+
+Check the operation output for a top-level `errors` field.
+If none, then the operation should have finished successfully.
+
+## (5) Check that the output exists
+
+* Replace `YOUR-BUCKET` with the bucket you used in the previous command.
+
+```
+$ gsutil ls -l gs://YOUR-BUCKET/wdl_runner/output
+        33  2017-10-04T04:22:21Z  gs://YOUR-BUCKET/wdl_runner/output/md5sum.txt
+      5264  2017-10-04T04:22:18Z  gs://YOUR-BUCKET/wdl_runner/output/wdl_run_metadata.json
+TOTAL: 2 objects, 5297 bytes (5.17 KiB)
+```
+
+## (6) Check the output
+
+```
+$ gsutil cat gs://YOUR-BUCKET/wdl_runner/output/md5sum.txt
+00579a00e3e7fa0674428ac7049423e2
+```
+
+## (7) Clean up the intermediate workspace files
+
+When Cromwell runs, per-stage output and other intermediate files are
+written to the WORKSPACE path you specified in the `gcloud` command above.
+
+If you wish to remove these files, run:
+
+```
+gsutil -m rm gs://YOUR-BUCKET/wdl_runner/work/**
+```
+

--- a/docs/GettingStarted/TutorialOverview.md
+++ b/docs/GettingStarted/TutorialOverview.md
@@ -1,4 +1,22 @@
-# WDL Runner Overview
+# WDL Runner Tutorial Overview
+
+## Note: just in case there are errors...
+
+We want this tutorial to be as useful to completely new users as possible. 
+If you find *anything* on this page (or any other) which is:
+
+* Not correct
+* Not obvious to you
+* Making undeclared assumptions
+* Worded obtusely
+  
+Then:
+ 
+* Please (please!) let us know!
+    * You can raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
+    * If you use github and are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
+
+## Tutorial Scenario
 
 This example demonstrates running a multi-stage workflow on
 Google Cloud Platform.

--- a/docs/GettingStarted/TutorialOverview.md
+++ b/docs/GettingStarted/TutorialOverview.md
@@ -51,3 +51,5 @@ The code in the wdl_runner Docker image includes:
 Take a look at the [Dockerfile](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/Dockerfile) for full details.
 
 ## Tutorial Steps
+
+Now that you've read the overview, you're probably itching to get started! You're ready for the [Tutorial Steps](TutorialSteps.md) themselves.

--- a/docs/GettingStarted/TutorialOverview.md
+++ b/docs/GettingStarted/TutorialOverview.md
@@ -1,0 +1,53 @@
+# WDL Runner Overview
+
+This example demonstrates running a multi-stage workflow on
+Google Cloud Platform.
+
+* The workflow is launched with the Google Genomics [Pipelines API](https://cloud.google.com/genomics/docs/quickstart).
+* The workflow is defined using the OpenWDL organization's
+[Workflow Definition Language](https://github.com/openwdl/wdl) (WDL).
+* The workflow stages are orchestrated by the Broad Institute's
+[Cromwell](https://github.com/broadinstitute/cromwell).
+
+When submitted using the Pipelines API, the workflow runs
+on multiple [Google Compute Engine](https://cloud.google.com/compute/)
+virtual machines.
+First a master node is created for Cromwell, and then Cromwell submits
+each stage of the workflow as one or more separate pipelines.
+
+Execution of a running Pipeline proceeds as:
+
+* Create Compute Engine virtual machine
+* On the VM, in a Docker container, execute wdl_runner.py
+    * Run Cromwell (server)
+    * Submit workflow, inputs, and options to Cromwell server
+    * Poll for completion as Cromwell executes:
+        1. Call pipelines.run() to execute call 1
+        2. Poll for completion of call 1
+        3. Call pipelines.run() to execute the next call
+        4. Poll for completion of the next call
+        5. Repeat steps 3-4 until all WDL "calls" complete>
+    * Copy workflow metadata to output path
+    * Copy workflow outputs to output path
+3. Destroy Compute Engine Virtual machine
+
+## Setup Overview
+
+Code packaging for the Pipelines API is done through
+[Docker](https://www.docker.com/) images.  The instructions provided
+here explain how to create your own Docker image, although a copy
+of this Docker image has already been built and made available by
+the Broad Institute.
+
+### Code summary
+
+The code in the wdl_runner Docker image includes:
+
+* [OpenJDK 8](http://openjdk.java.net/projects/jdk8/) runtime engine (JRE)
+* [Python 2.7](https://www.python.org/download/releases/2.7/) interpreter
+* [Cromwell release 36](https://github.com/broadinstitute/cromwell/releases/tag/36)
+* [Python and shell scripts from this repository](.)
+
+Take a look at the [Dockerfile](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/Dockerfile) for full details.
+
+## Tutorial Steps

--- a/docs/GettingStarted/TutorialSteps.md
+++ b/docs/GettingStarted/TutorialSteps.md
@@ -2,30 +2,13 @@
 
 This page is intended to be our first-stop tutorial for those new to using wdl_runner.
 
-## Note: just in case there are errors...
-
-We want this page to be as useful to completely new users as possible. 
-If you find *anything* on this page (or any other) which is:
-
-* Not correct
-* Not obvious to you
-* Making undeclared assumptions
-* Worded obtusely
-  
-Then:
- 
-* Please (please!) let us know!
-    * You can raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
-    * If you use github and are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
-
 ## Overview
 
-If you want to see an overview of what this tutorial is doing, you can find that [here](TutorialOverview.md).
+If you didn't already, you might want to read the overview of what this tutorial is doing [here](TutorialOverview.md).
+
 Otherwise you can jump straight in! All of the steps you'll need to follow are given below. 
 
 ## Tutorial Steps
-
-With that said, let's get started!
 
 ### (0) Prerequisites
 

--- a/docs/GettingStarted/TutorialSteps.md
+++ b/docs/GettingStarted/TutorialSteps.md
@@ -1,10 +1,11 @@
-# Quick Start
+# Quick Start Tutorial
 
 This page is intended to be our first-stop tutorial for those new to using wdl_runner.
 
 ## Note: just in case there are errors...
 
-We want this page to be as useful to completely new users as possible. If you find *anything* on this page which is:
+We want this page to be as useful to completely new users as possible. 
+If you find *anything* on this page (or any other) which is:
 
 * Not correct
 * Not obvious to you
@@ -17,90 +18,25 @@ Then:
     * You can raise this as an issue [here](https://github.com/broadinstitute/wdl-runner/issues) so that we can improve the tutorial and therefore hopefully improve the experience of future users.
     * If you use github and are so inclined, you are welcome to help us out by correcting the document yourself! Please submit any improvements you'd like to make as a pull request against the repository. This tutorial is stored in the repository [here](https://github.com/broadinstitute/wdl-runner/blob/master/docs/GettingStarted/QuickStart.md).
 
+## Overview
 
-# Tutorial
+If you want to see an overview of what this tutorial is doing, you can find that [here](TutorialOverview.md).
+Otherwise you can jump straight in! All of the steps you'll need to follow are given below. 
+
+## Tutorial Steps
 
 With that said, let's get started!
 
-## Overview
-
-This example demonstrates running a multi-stage workflow on
-Google Cloud Platform.
-
-* The workflow is launched with the Google Genomics [Pipelines API](https://cloud.google.com/genomics/docs/quickstart).
-* The workflow is defined using the OpenWDL organization's
-[Workflow Definition Language](https://github.com/openwdl/wdl) (WDL).
-* The workflow stages are orchestrated by the Broad Institute's
-[Cromwell](https://github.com/broadinstitute/cromwell).
-
-When submitted using the Pipelines API, the workflow runs
-on multiple [Google Compute Engine](https://cloud.google.com/compute/)
-virtual machines.
-First a master node is created for Cromwell, and then Cromwell submits
-each stage of the workflow as one or more separate pipelines.
-
-Execution of a running Pipeline proceeds as:
-
-1. Create Compute Engine virtual machine
-
-2. On the VM, in a Docker container, execute wdl_runner.py
-
-    a. Run Cromwell (server)
-
-    b. Submit workflow, inputs, and options to Cromwell server
-
-    c. Poll for completion as Cromwell executes:
-
-        1) Call pipelines.run() to execute call 1
-        
-        2) Poll for completion of call 1
-        
-        3) Call pipelines.run() to execute call 2
-        
-        4) Poll for completion of call 2
-        
-        <etc. until all WDL "calls" complete>
-
-    d. Copy workflow metadata to output path
-
-    e. Copy workflow outputs to output path
-
-3. Destroy Compute Engine Virtual machine
-
-## Setup Overview
-
-Code packaging for the Pipelines API is done through
-[Docker](https://www.docker.com/) images.  The instructions provided
-here explain how to create your own Docker image, although a copy
-of this Docker image has already been built and made available by
-the Broad Institute.
-
-### Code summary
-
-The code in the wdl_runner Docker image includes:
-
-* [OpenJDK 8](http://openjdk.java.net/projects/jdk8/) runtime engine (JRE)
-* [Python 2.7](https://www.python.org/download/releases/2.7/) interpreter
-* [Cromwell release 36](https://github.com/broadinstitute/cromwell/releases/tag/36)
-* [Python and shell scripts from this repository](.)
-
-Take a look at the [Dockerfile](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/Dockerfile) for full details.
-
-## (0) Prerequisites
+### (0) Prerequisites
 
 1. Clone or fork this repository.
-
 2. Enable the Genomics, Cloud Storage, and Compute Engine APIs on a new
    or existing Google Cloud Project using the [Cloud Console](https://console.cloud.google.com/flows/enableapi?apiid=genomics,storage_component,compute_component&redirect=https://console.cloud.google.com)
-
 3. Follow the Google Genomics [getting started instructions](https://cloud.google.com/genomics/docs/quickstart) to install and authorize the Google Cloud SDK.
-
 4. Follow the Cloud Storage instructions for [Creating Storage Buckets](https://cloud.google.com/storage/docs/creating-buckets) to create a bucket for workflow output and logging 
+5. If you plan to create your own Docker images, then [install docker](https://docs.docker.com/engine/installation/#installation)
 
-5. If you plan to create your own Docker images, then
-[install docker](https://docs.docker.com/engine/installation/#installation)
-
-## (1) Create and stage the wdl_runner Docker image
+### (1) Create and stage the wdl_runner Docker image
 
 *If you are going to use the published version of the docker image,
 then skip this step.*
@@ -111,7 +47,7 @@ serving Docker images called the [Google Container Registry](https://cloud.googl
 The following instructions allow you to stage a Docker image in your project's
 Container Registry with all necessary code for orchestrating your workflow.
 
-### (1a) Create the Docker image.
+#### (1a) Create the Docker image.
 
 ```
 git clone https://github.com/broadinstitute/wdl.git
@@ -119,7 +55,7 @@ cd runners/cromwell_on_google/wdl_runner/
 docker build -t ${USER}/wdl_runner .
 ```
 
-### (1b) Push the Docker image to a repository.
+#### (1b) Push the Docker image to a repository.
 
 In this example, we push the container to
 [Google Container Registry](https://cloud.google.com/container-registry/)
@@ -132,7 +68,7 @@ gcloud docker -- push gcr.io/YOUR-PROJECT-ID/wdl_runner
 
 * Replace `YOUR-PROJECT-ID` with your project ID.
 
-## (2) Run a test workflow in the cloud
+### (2) Run a test workflow in the cloud
 
 The file [wdl_pipeline.yaml](https://github.com/broadinstitute/wdl-runner/blob/master/wdl_runner/wdl_pipeline.yaml)
 defines a pipeline for running WDL workflows. By default, it uses the
@@ -152,7 +88,7 @@ docker:
 
 * Replace `YOUR-PROJECT-ID` with your project ID.
 
-#### Run the following command:
+##### Run the following command:
 
 * Replace `YOUR-BUCKET` with a bucket in your project.
 
@@ -171,7 +107,7 @@ OUTPUTS=gs://YOUR-BUCKET/wdl_runner/output \
 
 The output will be an operation ID for the Pipeline.
 
-## (3) Monitor the pipeline operation
+### (3) Monitor the pipeline operation
 
 This github repo includes a shell script,
 [monitoring_tools/monitor_wdl_pipeline.sh](https://github.com/broadinstitute/wdl-runner/blob/master/monitoring_tools/monitor_wdl_pipeline.sh),
@@ -229,12 +165,12 @@ Preemption retries:
   None
 ```
 
-## (4) Check the results
+### (4) Check the results
 
 Check the operation output for a top-level `errors` field.
 If none, then the operation should have finished successfully.
 
-## (5) Check that the output exists
+### (5) Check that the output exists
 
 * Replace `YOUR-BUCKET` with the bucket you used in the previous command.
 
@@ -245,14 +181,14 @@ $ gsutil ls -l gs://YOUR-BUCKET/wdl_runner/output
 TOTAL: 2 objects, 5297 bytes (5.17 KiB)
 ```
 
-## (6) Check the output
+### (6) Check the output
 
 ```
 $ gsutil cat gs://YOUR-BUCKET/wdl_runner/output/md5sum.txt
 00579a00e3e7fa0674428ac7049423e2
 ```
 
-## (7) Clean up the intermediate workspace files
+### (7) Clean up the intermediate workspace files
 
 When Cromwell runs, per-stage output and other intermediate files are
 written to the WORKSPACE path you specified in the `gcloud` command above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ The `wdl_runner` tool itself! This is a convenient tool which handles:
  * Spinning up a Cromwell server on a GCP VM 
  * Launching a WDL workflow by submitting it to the newly created Cromwell server. 
  
-See the [Quick Start](GettingStarted/QuickStart.md) page for a quick tutorial to get you started.
+See the [Quick Start](GettingStarted/TutorialSteps.md) page for a quick tutorial to get you started.
 
 ## Additional Monitoring Tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,13 @@
 
 Welcome to our user-facing documentation for the `wdl_runner` tool!
 
+This is a convenient tool which handles:
+ 
+ * Spinning up a Cromwell server on a GCP VM 
+ * Launching a WDL workflow by submitting it to the newly created Cromwell server.
+
 Since github repository documentation can get pretty heavily biased towards developers, these
-pages are intended to help you to:
+pages are intended to help new users to:
 
 - Get started with `wdl_runner` from scratch
 - Learn how to use `wdl_runner` in a variety of situations
@@ -15,23 +20,3 @@ If you want to get started as quickly as possible, We have a quick start tutoria
 * For an overview of what's included: [Tutorial Overview](GettingStarted/TutorialOverview.md).
 * To jump straight in to the tutorial and get started immediately: [Tutorial Steps](GettingStarted/TutorialSteps.md).
 
-# Repository Contents
-
-## The wdl_runner tool
-
-The `wdl_runner` tool itself! This is a convenient tool which handles:
- 
- * Spinning up a Cromwell server on a GCP VM 
- * Launching a WDL workflow by submitting it to the newly created Cromwell server. 
-
-## Additional Monitoring Tools
-
-Additional monitoring tools are stored in the '[monitoring_tools](https://github.com/broadinstitute/wdl-runner/tree/master/monitoring_tools)' directory of the
-`wdl-runner` repository.
-
-These are scripts that facilitate monitoring the status of WDL workflows run on GCP. 
-The main monitoring script is `monitor_wdl_pipeline.sh`. 
-It accepts an operation ID for a pipeline, extracts the LOGGING, WORKSPACE, and OUTPUT directories from the operation 
-and then examines these directories to glean some insights into the status of the operation.
-
-Note that if the WORKSPACE and/or OUTPUT directories for the specified operation are already populated (for example by another operation), this script will emit incorrect output.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,14 @@ pages are intended to help you to:
 - Get started with `wdl_runner` from scratch
 - Learn how to use `wdl_runner` in a variety of situations
 
+# Quick Start
 
-# Contents
+If you want to get started as quickly as possible, We have a quick start tutorial designed just for you!
+ 
+* For an overview of what's included: [Tutorial Overview](GettingStarted/TutorialOverview.md).
+* To jump straight in to the tutorial and get started immediately: [Tutorial Steps](GettingStarted/TutorialSteps.md).
+
+# Repository Contents
 
 ## The wdl_runner tool
 
@@ -17,8 +23,6 @@ The `wdl_runner` tool itself! This is a convenient tool which handles:
  
  * Spinning up a Cromwell server on a GCP VM 
  * Launching a WDL workflow by submitting it to the newly created Cromwell server. 
- 
-See the [Quick Start](GettingStarted/TutorialSteps.md) page for a quick tutorial to get you started.
 
 ## Additional Monitoring Tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# Welcome to WDL Runner!
+
+Welcome to our user-facing documentation for the `wdl_runner` tool!
+
+Since github repository documentation can get pretty heavily biased towards developers, these
+pages are intended to help you to:
+
+- Get started with `wdl_runner` from scratch
+- Learn how to use `wdl_runner` in a variety of situations
+
+
+# Contents
+
+## The wdl_runner tool
+
+The `wdl_runner` tool itself! This is a convenient tool which handles:
+ 
+ * Spinning up a Cromwell server on a GCP VM 
+ * Launching a WDL workflow by submitting it to the newly created Cromwell server. 
+ 
+See the [Quick Start](GettingStarted/QuickStart.md) page for a quick tutorial to get you started.
+
+## Additional Monitoring Tools
+
+Additional monitoring tools are stored in the '[monitoring_tools](https://github.com/broadinstitute/wdl-runner/tree/master/monitoring_tools)' directory of the
+`wdl-runner` repository.
+
+These are scripts that facilitate monitoring the status of WDL workflows run on GCP. 
+The main monitoring script is `monitor_wdl_pipeline.sh`. 
+It accepts an operation ID for a pipeline, extracts the LOGGING, WORKSPACE, and OUTPUT directories from the operation 
+and then examines these directories to glean some insights into the status of the operation.
+
+Note that if the WORKSPACE and/or OUTPUT directories for the specified operation are already populated (for example by another operation), this script will emit incorrect output.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,8 @@ repo_url: https://github.com/broadinstitute/wdl-runner
 pages:
 - Welcome: index.md
 - Getting Started:
-  - Quick Start Script: GettingStarted/QuickStart.md
+  - Tutorial Overview: GettingStarted/TutorialOverview.md
+  - Tutorial Steps: GettingStarted/TutorialSteps.md
 
 theme: readthedocs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: WDL Runner
+site_url: https://github.com/broadinstitute/wdl-runner
+site_description: WDL Runner User Documentation
+site_author: Broad Institute
+
+repo_url: https://github.com/broadinstitute/wdl-runner
+
+pages:
+- Welcome: index.md
+- Getting Started:
+  - Quick Start Script: GettingStarted/QuickStart.md
+
+theme: readthedocs
+
+extra_css:
+    - css/extra.css
+extra_javascript:
+    - js/extra.js
+
+# copyright: Copyright &copy; 2017 <a href="https://broadinstitute.org">Broad Institute</a>
+# google_analytics: ['identifierID', 'URL.org']


### PR DESCRIPTION
When reviewing please look at:

* Is the repo [front page](https://github.com/broadinstitute/wdl-runner/tree/cjl_readthedocs) looking good?
* Is the [readthedocs](https://wdl-runner.readthedocs.io/en/cjl_readthedocs/) page looking good?